### PR TITLE
Fetching Overhaul

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -146,17 +146,31 @@
                                                 "timestamp": {
                                                     "$ref": "#/components/schemas/ISOString"
                                                 },
+                                                "numInserted": {
+                                                    "type": "integer",
+                                                    "description": "The number of mods inserted in the last update."
+                                                },
                                                 "numUpdated": {
                                                     "type": "integer",
-                                                    "description": "The number of mods updated/inserted in the last update."
+                                                    "description": "The number of mods updated in the last update."
                                                 },
                                                 "numErrored": {
                                                     "type": "integer",
                                                     "description": "The number of mods that errored in the last update."
+                                                },
+                                                "numSkipped": {
+                                                    "type": "integer",
+                                                    "description": "The number of mods that were skipped over in the last update."
                                                 }
                                             },
                                             "additionalProperties": false,
-                                            "required": ["timestamp", "numUpdated", "numErrored"]
+                                            "required": [
+                                                "timestamp",
+                                                "numInserted",
+                                                "numUpdated",
+                                                "numErrored",
+                                                "numSkipped"
+                                            ]
                                         }
                                     },
                                     "additionalProperties": false,

--- a/server/package.json
+++ b/server/package.json
@@ -52,6 +52,7 @@
         "mongodb": "^5.4.0",
         "node-cron": "^3.0.2",
         "node-html-parser": "^6.1.5",
-        "swagger-ui-express": "^4.6.3"
+        "swagger-ui-express": "^4.6.3",
+        "tiny-typed-emitter": "^2.1.0"
     }
 }

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -28,6 +28,9 @@ dependencies:
   swagger-ui-express:
     specifier: ^4.6.3
     version: 4.6.3(express@4.18.2)
+  tiny-typed-emitter:
+    specifier: ^2.1.0
+    version: 2.1.0
 
 devDependencies:
   '@types/cors':
@@ -4571,6 +4574,10 @@ packages:
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
+
+  /tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
+    dev: false
 
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}

--- a/server/src/classes/MassRequester.ts
+++ b/server/src/classes/MassRequester.ts
@@ -205,7 +205,7 @@ export class MassRequester {
      * Attempts to successfully run an asynchronous function, retrying on failure.
      * @param {(args: TArgs) => Promise<TReturn>} fn The asynchronous function to run.
      * @param {TArgs} args Arguments to pass into the function.
-     * @param {(status: ProgressLoggerStatuses) => void} [logFn] A function to log status updates with.
+     * @param {(msg: string) => void} [logFn] A function to log status updates with.
      * @returns The successful return value of the function.
      * @throws Throws an error if the function fails after the {@link _maxAttempts maximum number} of retries.
      */
@@ -255,6 +255,7 @@ export class MassRequester {
         }
     }
 
+    /** Helper method for {@link logErrors}. */
     private static makeErrorMessage(err: unknown): string {
         if (axios.isAxiosError(err)) {
             if (err.response !== undefined) return `${err.response.status} (${err.response.statusText})`;

--- a/server/src/classes/MassRequester.ts
+++ b/server/src/classes/MassRequester.ts
@@ -1,0 +1,268 @@
+import axios from 'axios';
+import { TypedEmitter } from 'tiny-typed-emitter';
+import { Colours } from '../types/Colours';
+import { ProgressLogger } from './ProgressLogger';
+
+export interface ChunkEmitterEvents<T> {
+    /** Emitted data when a chunk has been fetched. */
+    chunk: (data: T[]) => void;
+
+    /** Emitted when all chunks have been fetched. */
+    done: (errors: FetchError[]) => void;
+}
+
+export type ChunkEmitter<T> = TypedEmitter<ChunkEmitterEvents<T>>;
+
+export interface FetchError {
+    key: string;
+    error: unknown;
+}
+
+/** Handles making large amount of asynchronous function calls in chunks. */
+export class MassRequester {
+    /** Whether to log status updates using a {@link ProgressLogger}. */
+    private readonly _loggingEnabled: boolean;
+
+    /** Maximum number of parallel requests allowed to occur. */
+    private readonly _chunkSize: number;
+
+    /** Maximum number of times to attempt requests. */
+    private readonly _maxAttempts: number;
+
+    /**
+     * If a request fails, how long to wait before retrying, in milliseconds.
+     *
+     * This number is multiplied by the attempt number.
+     *
+     * For example, a value of 1000 (1 second) will result in a 1 second delay between the first and second attempts, a
+     * 2 second delay between the second and third attempts, and so on...
+     */
+    private readonly _retryCooldownMultiplier: number;
+
+    /** Number of milliseconds between each sequential chunk fetch. */
+    private readonly _timeBetweenChunkFetches: number;
+
+    /**
+     * Creates a new {@link MassRequester} instance.
+     * @param {boolean} loggingEnabled Whether to log status updates using a {@link ProgressLogger}.
+     * @param {number} chunkSize Maximum number of parallel requests allowed to occur.
+     * @param {number} maxAttempts Maximum number of times to attempt requests.
+     * @param {number} retryCooldownMultiplier If a request fails, how long to wait before retrying, in milliseconds.
+     * @param {number} timeBetweenChunkFetches Number of milliseconds between each sequential chunk fetch.
+     */
+    public constructor(
+        loggingEnabled: boolean,
+        chunkSize: number,
+        maxAttempts: number,
+        retryCooldownMultiplier: number,
+        timeBetweenChunkFetches: number,
+    ) {
+        this._loggingEnabled = loggingEnabled;
+        this._chunkSize = chunkSize;
+        this._maxAttempts = maxAttempts;
+        this._retryCooldownMultiplier = retryCooldownMultiplier;
+        this._timeBetweenChunkFetches = timeBetweenChunkFetches;
+    }
+
+    /**
+     * Collects all results from a chunk emitter, and returns them once the emitter is done.
+     *
+     * It is not recommended to use this method for large amounts of data, as it will store all the data in memory,
+     * which defeats the whole purpose of having an emitter to begin with.
+     */
+    public static collectAllFromEmitter<T>(emitter: ChunkEmitter<T>): Promise<T[]> {
+        return new Promise((resolve) => {
+            const results: T[] = [];
+
+            emitter.on('chunk', (chunk) => {
+                results.push(...chunk);
+            });
+
+            emitter.on('done', () => {
+                resolve(results);
+            });
+        });
+    }
+
+    /**
+     * Performs a large amount of asynchronous function calls in chunks.
+     *
+     * This is done asynchronously using an {@link ChunkEmitter event emitter} so that the chunks can be processed as
+     * they come in, which helps reduce memory usage.
+     *
+     * For more information about the chunking process, see {@link chunkedFetch}.
+     */
+    public createChunkEmitter<TArgs, TResolve>(
+        fn: (args: TArgs) => Promise<TResolve>,
+        argsArray: TArgs[],
+        keyFn: (args: TArgs) => string,
+        failValue: TResolve,
+    ): ChunkEmitter<TResolve> {
+        const emitter = new TypedEmitter<ChunkEmitterEvents<TResolve>>();
+
+        if (argsArray.length === 0) {
+            // race condition where a 0 length array results in an emitter that emits 'done' before listeners are
+            // attached, so we need to delay the 'done' event by moving it to the next event loop
+            setTimeout(() => {
+                emitter.emit('done', []);
+                emitter.removeAllListeners();
+            }, 0);
+        } else {
+            this.chunkedFetch(fn, argsArray, keyFn, failValue, emitter).then((errors) => {
+                emitter.emit('done', errors);
+                emitter.removeAllListeners();
+            });
+        }
+
+        return emitter;
+    }
+
+    /**
+     * Splits up a large amount of asynchronous function calls into chunks.
+     * @param {(args: TArgs) => Promise<TResolve>} fn The asynchronous function to call. If a call to this function
+     * results in a rejected promise, it will be re-attempted {@link _maxAttempts} times (see {@link multiAttempt}).
+     * @param {TArgs[]} argsArray Arguments to pass to each call of the function, the length of this array determines
+     * the number of calls.
+     * @param {(args: TArgs) => string} keyFn A function that produces a unique identifier for each call, this is used
+     * if a call fails, so that it is clear which call resulted in the error.
+     * @param {TResolve} failValue The resolved value of calls that fail after exhausting all their attempts.
+     * @param {ChunkEmitter<TResolve>} emitter The event emitter to emit completed chunks to.
+     * @returns {Promise<FetchError[]>} Errors collected across all chunks.
+     *
+     * Chunks are processed sequentially, with the function calls within each chunk being awaited in parallel
+     * (using {@link Promise.all Promise.all}).
+     *
+     * After each chunk is processed, all of its resolved values are emitted using the supplied {@link ChunkEmitter}.
+     *
+     * All of the chunks' rejected values are collected as an array of {@link FetchError FetchErrors}, this
+     * is returned after all chunks have been processed.
+     */
+    private async chunkedFetch<TArgs, TResolve>(
+        fn: (args: TArgs) => Promise<TResolve>,
+        argsArray: TArgs[],
+        keyFn: (args: TArgs) => string,
+        failValue: TResolve,
+        emitter: ChunkEmitter<TResolve>,
+    ): Promise<FetchError[]> {
+        const itemCount = argsArray.length;
+        const chunkCount = Math.ceil(itemCount / this._chunkSize);
+
+        // errors across all chunks
+        const errors: FetchError[] = [];
+
+        for (let chunk = 0; chunk < chunkCount; chunk++) {
+            const chunkStartIndex = chunk * this._chunkSize;
+            const chunkEndIndex = (chunk + 1) * this._chunkSize;
+
+            const chunkArgs = argsArray.slice(chunkStartIndex, chunkEndIndex);
+
+            const trueChunkLength = chunkArgs.length; // last chunk may be smaller than chunkSize
+
+            const logger = this._loggingEnabled
+                ? new ProgressLogger(
+                      `Chunk ${(chunk + 1).toString().padStart(chunkCount.toString().length, ' ')} / ${chunkCount}`,
+                      trueChunkLength,
+                  )
+                : null;
+
+            // each promise represents a single call of the function
+            const promiseArray = new Array<Promise<TResolve>>(trueChunkLength);
+
+            for (let i = 0; i < trueChunkLength; i++) {
+                const args = chunkArgs[i];
+
+                promiseArray[i] = new Promise<TResolve>((resolve) => {
+                    this.multiAttempt(fn, args, (status) => logger?.log(i, status))
+                        .then(resolve)
+                        .catch((error) => {
+                            errors.push({ key: keyFn(args), error });
+                            // you may be asking, why have a fail value? why not just not resolve the promise, and have
+                            // promiseArray be appended to on resolve instead of fixed-length?
+                            //
+                            // this is because having a fixed-length array preserves the original order of the calls.
+                            // we also can't just resolve with a hard-coded fail value (e.g. null, undefined), because
+                            // it could conflict with TResolve
+                            resolve(failValue);
+                        });
+                });
+            }
+
+            const fetchedChunkData = await Promise.all(promiseArray);
+
+            logger?.close();
+
+            emitter.emit('chunk', fetchedChunkData);
+
+            if (chunk !== chunkCount - 1) {
+                await new Promise((resolve) => setTimeout(resolve, this._timeBetweenChunkFetches));
+            }
+        }
+
+        return errors;
+    }
+
+    /**
+     * Attempts to successfully run an asynchronous function, retrying on failure.
+     * @param {(args: TArgs) => Promise<TReturn>} fn The asynchronous function to run.
+     * @param {TArgs} args Arguments to pass into the function.
+     * @param {(status: ProgressLoggerStatuses) => void} [logFn] A function to log status updates with.
+     * @returns The successful return value of the function.
+     * @throws Throws an error if the function fails after the {@link _maxAttempts maximum number} of retries.
+     */
+    private async multiAttempt<TArgs, TReturn>(
+        fn: (args: TArgs) => Promise<TReturn>,
+        args: TArgs,
+        logFn?: (msg: string) => void,
+    ): Promise<TReturn> {
+        let numAttempts = 0;
+        let latestError: unknown;
+
+        while (numAttempts < this._maxAttempts) {
+            try {
+                const res = await fn(args);
+
+                logFn?.(`${Colours.FgGreen}x${Colours.Reset}`);
+
+                return res;
+            } catch (error) {
+                numAttempts++;
+
+                if (numAttempts === this._maxAttempts) {
+                    logFn?.(`${Colours.FgRed}e${Colours.Reset}`);
+                    latestError = error;
+                } else {
+                    logFn?.(`${Colours.FgYellow}r${Colours.Reset}`);
+                    await new Promise((resolve) => setTimeout(resolve, this._retryCooldownMultiplier * numAttempts));
+                }
+            }
+        }
+
+        throw latestError;
+    }
+
+    /**
+     * Logs an array of errors.
+     * @param {FetchError[]} errorArray Array of {@link FetchError} objects.
+     * @param {string} title Title of the error log.
+     */
+    public static logErrors(errorArray: FetchError[], title: string): void {
+        if (errorArray.length === 0) return;
+
+        console.log(`${Colours.FgRed}${errorArray.length} Errored ${title}:${Colours.Reset}`);
+
+        for (const { error, key } of errorArray) {
+            console.log(`${key}: ${MassRequester.makeErrorMessage(error)}`, error);
+        }
+    }
+
+    private static makeErrorMessage(err: unknown): string {
+        if (axios.isAxiosError(err)) {
+            if (err.response !== undefined) return `${err.response.status} (${err.response.statusText})`;
+            if (err.status !== undefined) return `${err.status} (${err.name})`;
+            if (err.code !== undefined) return `${err.code} (${err.name})`;
+            return `Unknown Axios Error (${err.name})`;
+        }
+        if (err instanceof Error) return `${err.name}`;
+        return 'Unknown';
+    }
+}

--- a/server/src/classes/MassRequester.ts
+++ b/server/src/classes/MassRequester.ts
@@ -18,7 +18,7 @@ interface FetchError {
     error: unknown;
 }
 
-/** Handles making large amount of asynchronous function calls in chunks. */
+/** Handles making large amounts of asynchronous function calls in chunks. */
 export class MassRequester {
     /** Whether to log status updates using a {@link ProgressLogger}. */
     private readonly _loggingEnabled: boolean;

--- a/server/src/classes/MassRequester.ts
+++ b/server/src/classes/MassRequester.ts
@@ -3,7 +3,7 @@ import { TypedEmitter } from 'tiny-typed-emitter';
 import { Colours } from '../types/Colours';
 import { ProgressLogger } from './ProgressLogger';
 
-export interface ChunkEmitterEvents<T> {
+interface ChunkEmitterEvents<T> {
     /** Emitted data when a chunk has been fetched. */
     chunk: (data: T[]) => void;
 
@@ -13,7 +13,7 @@ export interface ChunkEmitterEvents<T> {
 
 export type ChunkEmitter<T> = TypedEmitter<ChunkEmitterEvents<T>>;
 
-export interface FetchError {
+interface FetchError {
     key: string;
     error: unknown;
 }

--- a/server/src/classes/ProgressLogger.ts
+++ b/server/src/classes/ProgressLogger.ts
@@ -1,6 +1,3 @@
-import { Colours } from '../types/Colours';
-import { FetchError } from '../types/FetchError';
-
 /**
  * Handles routine logging of progress of multiple asynchronous tasks to `process.stdout`.
  *
@@ -10,7 +7,6 @@ import { FetchError } from '../types/FetchError';
  * 1. Instantiation
  * 2. {@link log Logging}
  * 3. {@link close Closing}
- * 4. (Optional) {@link logErrors Logging Errors}
  */
 export class ProgressLogger {
     /** Time between log messages, in seconds. */
@@ -18,6 +14,9 @@ export class ProgressLogger {
 
     /** Maximum character width of the terminal. */
     private readonly _maxWidth: number;
+
+    /** Title string to lead log messages with. */
+    private readonly _title: string;
 
     /** Output to log every interval, each item in this array should represent an asynchronous task. */
     private readonly _output: string[];
@@ -28,11 +27,14 @@ export class ProgressLogger {
     /** Internal interval tracker, referenced for cleanup. */
     private _interval: NodeJS.Timer;
 
+    /** Whether to actually write to the console, prevents writes when the output is unchanged. */
+    private _dirty = false;
+
     /**
      * Creates a new {@link ProgressLogger} instance.
      * @param {number} numItems The number of tasks to track.
      */
-    public constructor(numItems: number) {
+    public constructor(title: string, numItems: number) {
         try {
             this._maxWidth = process.stdout.getWindowSize()[0];
         } catch (error) {
@@ -40,68 +42,49 @@ export class ProgressLogger {
             this._maxWidth = -1;
         }
 
-        this._output = new Array<string>(numItems).fill('-');
+        this._title = title;
+        this._output = new Array(numItems).fill('-');
         this._rows = Math.ceil(numItems / this._maxWidth);
-        this._interval = setInterval(() => this.update(true), ProgressLogger._loggingInterval);
+        this._interval = setInterval(() => {
+            if (this._dirty) {
+                this._dirty = false;
+                this.clear();
+                this.update();
+            }
+        }, ProgressLogger._loggingInterval);
 
-        this.update(false);
+        this.update();
     }
 
     /**
      * Updates the status of a tracked asynchronous task.
      * @param {number} index The index of the task to update.
-     * @param {string} value New status value to log.
+     * @param {string} status New status to show this index as.
      */
-    public log(index: number, value: string): void {
-        this._output[index] = value;
+    public log(index: number, status: string): void {
+        this._output[index] = status;
+        this._dirty = true;
     }
 
-    /** Logs all task statuses to `process.stdout`, clearing the previous output (if supported). */
-    private update(replace: boolean): void {
-        if (replace && this._maxWidth !== -1) {
-            for (let i = 0; i < this._rows; i++) {
-                process.stdout.clearLine(0);
-                process.stdout.moveCursor(0, -1);
-            }
+    /** Clears the previous output (if supported). */
+    private clear(): void {
+        if (this._maxWidth === -1) return;
+
+        for (let i = 0; i <= this._rows; i++) {
+            process.stdout.clearLine(0);
+            process.stdout.moveCursor(0, -1);
         }
+    }
+
+    /** Logs all task statuses to `process.stdout`. */
+    private update(): void {
+        console.log(this._title);
         console.log(this._output.join(''));
     }
 
     /** Marks logging as finished. */
     public close(): void {
         clearInterval(this._interval);
-        this.update(true);
-    }
-
-    /**
-     * Logs an array of errors in a nice format.
-     * @param {FetchError[]} errorArray Array of error tuples, where the first item is the key and the second is
-     * the error message.
-     * @param {string} title Title of the error log.
-     */
-    public static logErrors(errorArray: FetchError[], title: string): void {
-        if (errorArray.length === 0) return;
-
-        console.log(`${Colours.FgRed}${errorArray.length} Errored ${title}:${Colours.Reset}`);
-
-        const maxKeyLength = Math.max(...errorArray.map((e) => e.key.length));
-        const maxTotalLength = Math.max(...errorArray.map((e) => e.message.length)) + maxKeyLength + 10;
-
-        let errorsPerLine: number;
-        try {
-            errorsPerLine = Math.floor(process.stdout.getWindowSize()[0] / maxTotalLength);
-        } catch (error) {
-            // some environments don't seem to have a process.stdout, such as pm2
-            errorsPerLine = 1;
-        }
-
-        for (let i = 0, len = errorArray.length; i < len; i += errorsPerLine) {
-            console.log(
-                errorArray
-                    .slice(i, i + errorsPerLine)
-                    .map((e) => `${e.key.padStart(maxKeyLength, ' ')}: ${e.message}`.padEnd(maxTotalLength, ' '))
-                    .join('|'),
-            );
-        }
+        this.clear();
     }
 }

--- a/server/src/classes/ProgressLogger.ts
+++ b/server/src/classes/ProgressLogger.ts
@@ -1,7 +1,7 @@
 /**
- * Handles routine logging of progress of multiple asynchronous tasks to `process.stdout`.
+ * Handles routine logging of progress to `process.stdout`.
  *
- * The static {@link logErrors} method can be used to log errors in a nice format.
+ * Progress is represented as an array of strings, where each string represents the status of a task.
  *
  * The basic lifecycle of a logger is:
  * 1. Instantiation
@@ -32,6 +32,7 @@ export class ProgressLogger {
 
     /**
      * Creates a new {@link ProgressLogger} instance.
+     * @param {string} title Title string to lead log messages with.
      * @param {number} numItems The number of tasks to track.
      */
     public constructor(title: string, numItems: number) {
@@ -45,6 +46,7 @@ export class ProgressLogger {
         this._title = title;
         this._output = new Array(numItems).fill('-');
         this._rows = Math.ceil(numItems / this._maxWidth);
+
         this._interval = setInterval(() => {
             if (this._dirty) {
                 this._dirty = false;
@@ -76,7 +78,7 @@ export class ProgressLogger {
         }
     }
 
-    /** Logs all task statuses to `process.stdout`. */
+    /** Logs all task statuses to the console. */
     private update(): void {
         console.log(this._title);
         console.log(this._output.join(''));

--- a/server/src/classes/WorkshopFetcher.ts
+++ b/server/src/classes/WorkshopFetcher.ts
@@ -1,22 +1,19 @@
 import axios, { AxiosRequestConfig } from 'axios';
-import { Colours } from '../types/Colours';
-import { FetchError } from '../types/FetchError';
 import { Mod } from '../types/Mod';
-import { PageResponse } from '../types/PageResponse';
 import { ModId } from '../types/Utility';
-import { ProgressLogger } from './ProgressLogger';
+import { ChunkEmitter, MassRequester } from './MassRequester';
 import { WorkshopParser } from './WorkshopParser';
 
 /**
  * Handles fetching of workshop items from the Steam Workshop.
  *
- * The static {@link fetchSingleItem} method can be used to fetch a single workshop item.
+ * The static {@link fetchMod} method can be used to fetch a single workshop item.
  *
  * The basic lifecycle of a fetcher is:
  * 1. Instantiation
  * 2. {@link fetchNumPages Fetching number of pages}.
  * 3. {@link fetchAllPages Fetching all page data}.
- * 4. {@link fetchAllItems Fetching all item data}.
+ * 4. {@link fetchAllMods Fetching all item data}.
  *
  * @example
  * ```ts
@@ -43,38 +40,23 @@ import { WorkshopParser } from './WorkshopParser';
  * ```
  */
 export class WorkshopFetcher {
-    private static readonly _pageUrl: string = 'https://steamcommunity.com/workshop/browse' as const;
+    private static readonly _pageUrl: string = 'https://steamcommunity.com/workshop/browse';
     private static readonly _itemUrl: string = 'https://steamcommunity.com/sharedfiles/filedetails';
 
-    /** Maximum number of times to attempt network requests. */
-    private static readonly _maxAttempts: number = 3;
+    /** Requester for making mass network requests to. */
+    private readonly _massRequester: MassRequester;
 
-    /** Maximum number of parallel requests. */
-    private static readonly _chunkSize: number = 300;
-
-    /**
-     * If a request fails, how long to wait before retrying, in milliseconds.
-     *
-     * This number is multiplied by the attempt number.
-     *
-     * For example, a value of 1000 (1 second) will result in a 1 second delay between the first and second attempts, a
-     * 2 second delay between the second and third attempts, and so on...
-     */
-    private static readonly _retryCooldownMultiplier: number = 1_000;
-
+    /** Query parameters to send with network requests. */
     private readonly _params: AxiosRequestConfig['params'];
 
-    /** Whether to log mass network requests using a {@link ProgressLogger}. */
-    private readonly _verbose: boolean;
-
     /**
-     * Instantiates a new workshop fetcher.
-     * @param {boolean} verbose Whether to log mass network requests using a {@link ProgressLogger}.
+     * Creates a new {@link WorkshopFetcher} instance.
+     * @param {boolean} loggingEnabled Whether to log mass network requests.
      * @param {number} postedSince Timestamp (in seconds) for start of 'posted date' range filter.
      * @param {number} updatedSince Timestamp (in seconds) for start of 'date last updated' range filter.
      */
-    public constructor(verbose: boolean = false, postedSince: number = 0, updatedSince: number = 0) {
-        this._verbose = verbose;
+    public constructor(loggingEnabled: boolean = false, postedSince: number = 0, updatedSince: number = 0) {
+        this._massRequester = new MassRequester(loggingEnabled, 300, 3, 1_000, 100);
 
         this._params = {
             appid: 294100,
@@ -94,13 +76,8 @@ export class WorkshopFetcher {
      * Fetches the number of pages of mods on the workshop.
      *
      * This is done by fetching the first page and seeing what the maximum page number on it is.
-     *
-     * Since this fetches the first page, it also fetches the mod IDs on that page.
-     *
-     * @returns {Promise<PageResponse>} The response from the first page, this is required to call
-     * {@link fetchAllPages}.
      */
-    public async fetchNumPages(): Promise<PageResponse> {
+    public async fetchNumPages(): Promise<number> {
         const { data } = await axios.get<string>(WorkshopFetcher._pageUrl, {
             params: {
                 ...this._params,
@@ -108,47 +85,54 @@ export class WorkshopFetcher {
             },
         });
 
-        return WorkshopParser.parsePage(data, true);
+        return WorkshopParser.parsePageCount(data);
     }
 
     /**
      * Fetches the content of each page of mods on the workshop.
-     * @param {PageResponse} pageResponse The response from {@link fetchNumPages}, this is required as it contains the
-     * number of pages needed to be fetched, as well as the IDs of all the mods on the first page.
-     * @returns {Promise<ModId[]>} The mod IDs from all pages, this is required to call {@link fetchAllItems}.
+     * @param {number} [numPages] The number of pages to fetch. If omitted, all pages will be fetched.
+     * @returns {Promise<ChunkEmitter<ModId[]>>} A chunk emitter, each chunk contains an array of pages, which
+     * themselves contain an array of mod IDs.
      */
-    public async fetchAllPages(pageResponse: PageResponse): Promise<ModId[]> {
-        const { pageCount, ids } = pageResponse;
+    public async fetchAllPages(numPages?: number): Promise<ChunkEmitter<ModId[]>> {
+        numPages ??= await this.fetchNumPages();
 
-        if (pageCount === 0) return [];
+        const argsArray = new Array(numPages).fill(0).map((_, i) => i + 1); // page number starts at 1
 
-        const argsArray = new Array(pageCount - 1).fill(0).map((_, i) => i + 2);
-        const keyArray = new Array(pageCount - 1).fill(0).map((_, i) => (i + 2).toString());
-        const erroredPages: FetchError[] = [];
-
-        const fetchedData = await this.chunkedFetch(
-            (args) => this.fetchPageItems(args),
+        return this._massRequester.createChunkEmitter(
+            (args) => this.fetchPage(args),
             argsArray,
-            keyArray,
-            erroredPages,
+            (args) => args.toString(),
             [],
         );
-
-        fetchedData.splice(0, 0, ids);
-
-        ProgressLogger.logErrors(erroredPages, 'pages');
-
-        return fetchedData.flat();
     }
 
     /**
-     * Internal helper method used by {@link fetchAllPages} to fetch an individual page.
-     * @param {number} pageNumber The page number
+     * Fetches an array of mods.
+     * @param {ModId[]} ids Array of mod IDs to fetch the content of.
+     * @returns {Promise<ChunkEmitter<Mod | null>>} A chunk emitter, each chunk contains an array of mods.
+     */
+    public async fetchAllMods(ids?: ModId[]): Promise<ChunkEmitter<Mod | null>> {
+        ids ??= (await MassRequester.collectAllFromEmitter(await this.fetchAllPages())).flat();
+
+        const argsArray = new Array(ids.length).fill(0).map((_, i) => ids![i]);
+
+        return this._massRequester.createChunkEmitter(
+            (args) => WorkshopFetcher.fetchMod(args),
+            argsArray,
+            (args) => args,
+            null,
+        );
+    }
+
+    /**
+     * Fetches a single page of mods.
+     * @param {number} pageNumber The page number, starts at 1.
      * @returns {Promise<ModId[]>} The mod IDs on the page.
      *
-     * The page number should start at 2, since the first page is fetched by {@link fetchNumPages}.
+     * This is not a static method as page contents are dependent on the instance's {@link _params}.
      */
-    private async fetchPageItems(pageNumber: number): Promise<ModId[]> {
+    private async fetchPage(pageNumber: number): Promise<ModId[]> {
         const { data } = await axios.get<string>(WorkshopFetcher._pageUrl, {
             params: {
                 ...this._params,
@@ -156,40 +140,11 @@ export class WorkshopFetcher {
             },
         });
 
-        return WorkshopParser.parsePage(data);
+        return WorkshopParser.parsePageMods(data);
     }
 
-    /**
-     * Fetches the content of each mod on the workshop.
-     * @param {ModId[]} ids The mod IDs from all pages, this is returned from {@link fetchAllPages}.
-     * @returns {Promise<Mod[]>} The content of each mod on the workshop.
-     */
-    public async fetchAllItems(ids: ModId[]): Promise<Mod[]> {
-        const itemCount = ids.length;
-
-        const argsArray = new Array(itemCount).fill(0).map((_, i) => ids[i]);
-        const keyArray = argsArray;
-        const erroredItems: FetchError[] = [];
-
-        const fetchedData = await this.chunkedFetch(
-            (args) => WorkshopFetcher.fetchSingleItem(args),
-            argsArray,
-            keyArray,
-            erroredItems,
-            null,
-        );
-
-        ProgressLogger.logErrors(erroredItems, 'items');
-
-        return fetchedData.filter((e): e is Mod => e !== null);
-    }
-
-    /**
-     * Fetches a single workshop item.
-     *
-     * Used internally by {@link fetchAllItems}.
-     */
-    public static async fetchSingleItem(id: ModId): Promise<Mod> {
+    /** Fetches a single workshop item. */
+    public static async fetchMod(id: ModId): Promise<Mod | null> {
         const { data } = await axios.get<string>(WorkshopFetcher._itemUrl, {
             params: {
                 id,
@@ -198,7 +153,9 @@ export class WorkshopFetcher {
 
         const parser = new WorkshopParser(data);
 
-        return {
+        if (parser.getIsInaccessible()) return null;
+
+        const mod: Mod = {
             _id: id,
             thumbnail: parser.getThumbnail(),
             title: parser.getTitle(),
@@ -210,139 +167,15 @@ export class WorkshopFetcher {
             dlcs: parser.getDlcs(),
             size: parser.getSize(),
             posted: parser.getPosted(),
-            updated: parser.getUpdated(),
             catalogueLastUpdated: new Date().toISOString(),
             statsVisitors: parser.getVisitors(),
             statsSubscribers: parser.getSubscribers(),
             statsFavourites: parser.getFavourites(),
         };
-    }
 
-    /**
-     * Performs a large amount of asynchronous requests in chunks.
-     * @param {(args: TArgs) => Promise<TResolve>} fn The asynchronous function to call. This will be attempted
-     * {@link _maxAttempts} times (for every item in {@link argsArray}).
-     * @param {TArgs[]} argsArray Arguments to pass to each call of the function, the length of this array determines
-     * the number of calls.
-     * @param {string[]} keyArray Unique identifier for each call, used for logging errors.
-     * @param {FetchError[]} errorArray Array to store errors in.
-     * @param {TResolve} failValue The value to return if a call fails after exhausting all attempts.
-     * @returns {Promise<TResolve[]>}
-     */
-    private async chunkedFetch<TArgs, TResolve>(
-        fn: (args: TArgs) => Promise<TResolve>,
-        argsArray: TArgs[],
-        keyArray: string[],
-        errorArray: FetchError[],
-        failValue: TResolve,
-    ): Promise<TResolve[]> {
-        const itemCount = argsArray.length;
-        const chunkCount = Math.ceil(itemCount / WorkshopFetcher._chunkSize);
+        const updated = parser.getUpdated();
+        if (updated !== undefined) mod.updated = updated;
 
-        const output: TResolve[] = new Array(itemCount);
-
-        for (let chunk = 0; chunk < chunkCount; chunk++) {
-            const chunkStartIndex = chunk * WorkshopFetcher._chunkSize;
-            const chunkEndIndex = (chunk + 1) * WorkshopFetcher._chunkSize;
-
-            const chunkArgs = argsArray.slice(chunkStartIndex, chunkEndIndex);
-            const chunkKeys = keyArray.slice(chunkStartIndex, chunkEndIndex);
-
-            const trueChunkLength = chunkArgs.length;
-
-            let logger: ProgressLogger | undefined;
-
-            if (this._verbose) {
-                console.log(
-                    `Fetching chunk (${(chunk + 1)
-                        .toString()
-                        .padStart(chunkCount.toString().length, ' ')}/${chunkCount})`,
-                );
-                logger = new ProgressLogger(trueChunkLength);
-            }
-
-            const promiseArray = new Array<Promise<TResolve>>(trueChunkLength);
-
-            for (let i = 0; i < trueChunkLength; i++) {
-                const args = chunkArgs[i];
-                const key = chunkKeys[i];
-
-                promiseArray[i] = new Promise<TResolve>((resolve) => {
-                    WorkshopFetcher.multiAttempt(fn, args, (msg) => logger?.log(i, msg))
-                        .then(resolve)
-                        .catch((error) => {
-                            errorArray.push({
-                                key,
-                                message: WorkshopFetcher.handleError(error),
-                                error,
-                            });
-                            resolve(failValue);
-                        });
-                });
-            }
-
-            const fetchedChunkData = await Promise.all(promiseArray);
-
-            logger?.close();
-
-            for (let i = 0; i < trueChunkLength; i++) {
-                output[chunkStartIndex + i] = fetchedChunkData[i];
-            }
-        }
-
-        return output;
-    }
-
-    /**
-     * Attempts to successfully run an asynchronous function mutliple times.
-     * @param {(args: TArgs) => Promise<TReturn>} fn The asynchronous function to run.
-     * @param {TArgs} args Arguments to pass into the function.
-     * @param {(msg: string) => void} [logFn] A function to log messages with.
-     * @returns The successful return value of the function.
-     * @throws Throws an error if the function fails after the {@link _maxAttempts maximum number} of attempts.
-     */
-    private static async multiAttempt<TArgs, TReturn>(
-        fn: (args: TArgs) => Promise<TReturn>,
-        args: TArgs,
-        logFn?: (msg: string) => void,
-    ): Promise<TReturn> {
-        let numAttempts = 0;
-        let latestError: unknown;
-
-        while (numAttempts < WorkshopFetcher._maxAttempts) {
-            try {
-                const res = await fn(args);
-
-                logFn?.(`${Colours.FgGreen}x${Colours.Reset}`);
-
-                return res;
-            } catch (error) {
-                numAttempts++;
-
-                if (numAttempts === WorkshopFetcher._maxAttempts) {
-                    logFn?.(`${Colours.FgRed}e${Colours.Reset}`);
-                    latestError = error;
-                } else {
-                    logFn?.(`${Colours.FgYellow}e${Colours.Reset}`);
-                    await new Promise((resolve) =>
-                        setTimeout(resolve, WorkshopFetcher._retryCooldownMultiplier * numAttempts),
-                    );
-                }
-            }
-        }
-
-        throw latestError;
-    }
-
-    /** Nicely formats an unknown error. */
-    private static handleError(err: unknown): string {
-        if (axios.isAxiosError(err)) {
-            if (err.response !== undefined) return `${err.response.status} (${err.response.statusText})`;
-            if (err.status !== undefined) return `${err.status} (${err.name})`;
-            if (err.code !== undefined) return `${err.code} (${err.name})`;
-            return `Unknown Axios Error (${err.name})`;
-        }
-        if (err instanceof Error) return `${err.name}`;
-        return 'Unknown';
+        return mod;
     }
 }

--- a/server/src/classes/WorkshopParser.ts
+++ b/server/src/classes/WorkshopParser.ts
@@ -4,13 +4,12 @@ import { TAG_KEYWORDS } from '../constants/tags';
 import { ModAuthor } from '../types/ModAuthor';
 import { ModDLCs } from '../types/ModDLCs';
 import { ModTags } from '../types/ModTags';
-import { PageResponse } from '../types/PageResponse';
 import { ModId } from '../types/Utility';
 
 /**
  * Handles HTML parsing of workshop items into properties of the {@link Mod} object.
  *
- * The static {@link parsePage} method can be used to parse a page of workshop items.
+ * The static {@link parsePageMods} method can be used to parse a page of workshop items.
  */
 export class WorkshopParser {
     /** Contains the entire HTML DOM. */
@@ -30,6 +29,15 @@ export class WorkshopParser {
         this._ratingSection = this._root.querySelector('.ratingSection');
         this._detailsElements = this._root.querySelectorAll('.detailsStatRight');
         this._statsElements = this._root.querySelector('.stats_table')?.querySelectorAll('td');
+    }
+
+    /**
+     * Some mods require the client to be logged in to view, such as those with explicit content tags.
+     *
+     * E.g. https://steamcommunity.com/sharedfiles/filedetails/?id=2911258858
+     */
+    public getIsInaccessible(): boolean {
+        return this._root.querySelector('#message') !== null;
     }
 
     public getThumbnail(): string {
@@ -167,9 +175,7 @@ export class WorkshopParser {
      * @param {string} rawData The raw HTML data of the page.
      * @param {boolean} [includePageCount] Whether to include the page count in the returned object.
      */
-    public static parsePage(rawData: string, includePageCount: true): PageResponse;
-    public static parsePage(rawData: string, includePageCount?: false): ModId[];
-    public static parsePage(rawData: string, includePageCount?: boolean): PageResponse | ModId[] {
+    public static parsePageMods(rawData: string): ModId[] {
         const root = parse(rawData);
 
         const ids = root
@@ -177,14 +183,16 @@ export class WorkshopParser {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             .map<ModId>((e) => (e.childNodes[1] as any).attributes['data-publishedfileid']);
 
-        if (!includePageCount) return ids;
+        return ids;
+    }
+
+    public static parsePageCount(rawData: string): number {
+        const root = parse(rawData);
 
         const pageElements = root.querySelectorAll('.pagelink');
 
-        if (pageElements.length === 0) return { ids: [], pageCount: 0 };
+        if (pageElements.length === 0) return 0;
 
-        const pageCount = parseInt(pageElements[pageElements.length - 1].innerText.replace(',', ''));
-
-        return { ids, pageCount };
+        return parseInt(pageElements[pageElements.length - 1].innerText.replace(',', ''));
     }
 }

--- a/server/src/classes/WorkshopParser.ts
+++ b/server/src/classes/WorkshopParser.ts
@@ -65,7 +65,7 @@ export class WorkshopParser {
         - unknown stars https://community.akamai.steamstatic.com/public/images/sharedfiles/not-yet_large.png?v=2 
         */
         const ratingStarsString = this._ratingSection?.querySelector('img')?.getAttribute('src') ?? '';
-        // extract star count via capture group in RegExp
+        // extract star count via capture group in RegExp (ty @pumbas600)
         return parseInt(/([0-5])-star/i.exec(ratingStarsString)?.at(1) ?? '0');
     }
 
@@ -171,9 +171,8 @@ export class WorkshopParser {
     }
 
     /**
-     * Gets the page count and contained item IDs from a page.
+     * Gets the contained item IDs from a page.
      * @param {string} rawData The raw HTML data of the page.
-     * @param {boolean} [includePageCount] Whether to include the page count in the returned object.
      */
     public static parsePageMods(rawData: string): ModId[] {
         const root = parse(rawData);
@@ -186,6 +185,10 @@ export class WorkshopParser {
         return ids;
     }
 
+    /**
+     * Gets the page count from a page.
+     * @param {stirng} rawData The raw HTML data of the page.
+     */
     public static parsePageCount(rawData: string): number {
         const root = parse(rawData);
 

--- a/server/src/services/ModService.ts
+++ b/server/src/services/ModService.ts
@@ -32,7 +32,7 @@ export async function getTotalModCount(): Promise<number> {
     return await getModel().estimatedDocumentCount();
 }
 
-export async function upsert(mods: Mod[]): Promise<[inserted: number, updated: number]> {
+export async function upsertMods(mods: Mod[]): Promise<[inserted: number, updated: number]> {
     if (mods.length === 0) return [0, 0];
 
     const bulkUpdateOperations = mods.map<AnyBulkWriteOperation<Mod>>((mod) => ({

--- a/server/src/services/ModService.ts
+++ b/server/src/services/ModService.ts
@@ -32,8 +32,8 @@ export async function getTotalModCount(): Promise<number> {
     return await getModel().estimatedDocumentCount();
 }
 
-export async function upsert(mods: Mod[]): Promise<void> {
-    if (mods.length === 0) return;
+export async function upsert(mods: Mod[]): Promise<[inserted: number, updated: number]> {
+    if (mods.length === 0) return [0, 0];
 
     const bulkUpdateOperations = mods.map<AnyBulkWriteOperation<Mod>>((mod) => ({
         updateOne: {
@@ -43,7 +43,9 @@ export async function upsert(mods: Mod[]): Promise<void> {
         },
     }));
 
-    await getModel().bulkWrite(bulkUpdateOperations);
+    const bulkWriteResult = await getModel().bulkWrite(bulkUpdateOperations);
+
+    return [bulkWriteResult.upsertedCount, bulkWriteResult.modifiedCount];
 }
 
 export async function searchMods(searchOptions: ModSearchOptions): Promise<WithPagination<Mod>> {

--- a/server/src/services/UpdateService.ts
+++ b/server/src/services/UpdateService.ts
@@ -10,15 +10,19 @@ It is designed to be run on a schedule, and will:
 */
 
 import { Collection, Db } from 'mongodb';
+import { MassRequester } from '../classes/MassRequester';
 import { WorkshopFetcher } from '../classes/WorkshopFetcher';
 import { Colours } from '../types/Colours';
+import { Mod } from '../types/Mod';
 import { ISOString } from '../types/Utility';
 import { upsert } from './ModService';
 
 interface UpdateData {
     timestamp: ISOString;
+    numInserted: number;
     numUpdated: number;
     numErrored: number;
+    numSkipped: number;
 }
 
 let model: Collection<UpdateData> | null = null;
@@ -45,65 +49,135 @@ export async function setLastUpdate(newUpdate: UpdateData): Promise<void> {
 async function performInitialWorkshopFetch(): Promise<void> {
     const updateStartTime = new Date();
 
-    console.log('Initial mod insert starting, please do not exit the process');
+    console.log('Initial mod fetch starting, please do not exit the process');
     const fetcher = new WorkshopFetcher(true);
 
     console.log(`[1/5] Fetching ${Colours.FgCyan}number of pages${Colours.Reset}...`);
-    const initialPageData = await fetcher.fetchNumPages();
+    const pageCount = await fetcher.fetchNumPages();
 
     console.log(
-        `[2/5] Fetching ${Colours.FgMagenta}mod IDs${Colours.Reset} from ${Colours.FgCyan}${initialPageData.pageCount}${Colours.Reset} pages...`,
+        `[2/5] Fetching ${Colours.FgMagenta}mod IDs${Colours.Reset} from ${Colours.FgCyan}${pageCount}${Colours.Reset} pages...`,
     );
-    const modIds = await fetcher.fetchAllPages(initialPageData);
+    const pageEmitter = await fetcher.fetchAllPages(pageCount);
 
-    console.log(
-        `[3/5] Fetching ${Colours.FgGreen}data${Colours.Reset} for ${Colours.FgMagenta}${modIds.length}${Colours.Reset} mods IDs...`,
-    );
-    const allMods = await fetcher.fetchAllItems(modIds);
+    let pagesReceived = 0;
 
-    console.log(`[4/5] Updating ${Colours.FgGreen}${allMods.length}${Colours.Reset} mods in the database...`);
-    await upsert(allMods);
+    const modIds: string[] = [];
 
-    console.log('[5/5] Saving results...');
-    await setLastUpdate({
-        timestamp: updateStartTime.toISOString(),
-        numUpdated: allMods.length,
-        numErrored: 0,
+    pageEmitter.on('chunk', (pageChunk) => {
+        pagesReceived += pageChunk.length;
+        modIds.push(...pageChunk.flat());
+    });
+
+    await new Promise<void>((resolve) => {
+        pageEmitter.on('done', (errors) => {
+            MassRequester.logErrors(errors, 'pages');
+            resolve();
+        });
     });
 
     console.log(
-        `Initial mod insert completed successfully (took ${Math.floor(
+        `[3/5] Fetching ${Colours.FgGreen}mod data${Colours.Reset} for ${Colours.FgMagenta}${modIds.length}${Colours.Reset} mod IDs across ${Colours.FgCyan}${pagesReceived}${Colours.Reset} pages...`,
+    );
+
+    let modsErrored = 0;
+    let modsSkipped = 0;
+    const upsertPromises: Promise<[inserted: number, updated: number]>[] = [];
+
+    const modEmitter = await fetcher.fetchAllMods(modIds.flat());
+
+    modEmitter.on('chunk', (modChunk) => {
+        const trueModChunk = modChunk.filter((mod): mod is Mod => mod !== null);
+        upsertPromises.push(upsert(trueModChunk));
+        modsSkipped += modChunk.length - trueModChunk.length;
+    });
+
+    await new Promise<void>((resolve) => {
+        modEmitter.on('done', (errors) => {
+            MassRequester.logErrors(errors, 'mods');
+            modsErrored = errors.length;
+            resolve();
+        });
+    });
+
+    console.log(`[4/5] Updating database (${upsertPromises.length} operations)...`);
+    const [inserted, updated] = (await Promise.all(upsertPromises)).reduce(
+        (a, b) => [a[0] + b[0], a[1] + b[1]],
+        [0, 0],
+    );
+
+    console.log(
+        `[5/5] Saving results (${Colours.FgGreen}inserted${Colours.Reset} = ${inserted}, ${Colours.FgMagenta}updated${Colours.Reset} = ${updated}, ${Colours.FgRed}errored${Colours.Reset} = ${modsErrored}, ${Colours.FgYellow}skipped${Colours.Reset} = ${modsSkipped})...`,
+    );
+    await setLastUpdate({
+        timestamp: updateStartTime.toISOString(),
+        numInserted: inserted,
+        numUpdated: updated,
+        numErrored: modsErrored,
+        numSkipped: modsSkipped,
+    });
+
+    console.log(
+        `Initial mod fetch completed successfully (took ${Math.floor(
             (Date.now() - updateStartTime.getTime()) / 1_000,
         ).toLocaleString('en-NZ')}s)`,
     );
 }
 
-async function performWorkshopUpdate(timestamp: number, mode: 'posted' | 'updated'): Promise<void> {
+async function performBackgroundWorkshopFetch(timestamp: number, mode: 'posted' | 'updated'): Promise<UpdateData> {
     const updateStartTime = new Date();
 
+    console.log(
+        `Background mod fetch starting for ${mode === 'posted' ? Colours.FgMagenta : Colours.FgCyan}${mode}${
+            Colours.Reset
+        } mods`,
+    );
     const fetcher = new WorkshopFetcher(false, mode === 'posted' ? timestamp : 0, mode === 'updated' ? timestamp : 0);
 
-    const initialPageData = await fetcher.fetchNumPages();
+    let modsErrored = 0;
+    let modsSkipped = 0;
+    const upsertPromises: Promise<[inserted: number, updated: number]>[] = [];
 
-    const modIds = await fetcher.fetchAllPages(initialPageData);
+    const modEmitter = await fetcher.fetchAllMods();
 
-    const allMods = await fetcher.fetchAllItems(modIds);
-
-    await upsert(allMods);
-
-    await setLastUpdate({
-        timestamp: updateStartTime.toISOString(),
-        numUpdated: allMods.length,
-        numErrored: 0,
+    modEmitter.on('chunk', (modChunk) => {
+        const trueModChunk = modChunk.filter((mod): mod is Mod => mod !== null);
+        upsertPromises.push(upsert(trueModChunk));
+        modsSkipped += modChunk.length - trueModChunk.length;
     });
+
+    await new Promise<void>((resolve) => {
+        modEmitter.on('done', (errors) => {
+            MassRequester.logErrors(errors, 'mods');
+            modsErrored = errors.length;
+            resolve();
+        });
+    });
+
+    const [inserted, updated] = (await Promise.all(upsertPromises)).reduce(
+        (a, b) => [a[0] + b[0], a[1] + b[1]],
+        [0, 0],
+    );
 
     console.log(
         `Background refresh for ${mode === 'posted' ? Colours.FgMagenta : Colours.FgCyan}${mode}${
             Colours.Reset
         } mods completed successfully (took ${Math.floor(
             (Date.now() - updateStartTime.getTime()) / 1_000,
-        ).toLocaleString('en-NZ')}s, ${allMods.length} mods updated, ${0} errored)`,
+        ).toLocaleString('en-NZ')}s, ${Colours.FgGreen}inserted${Colours.Reset} = ${inserted}, ${
+            Colours.FgMagenta
+        }updated${Colours.Reset} = ${updated}, ${Colours.FgRed}errored${Colours.Reset} = ${modsErrored}, ${
+            Colours.FgYellow
+        }skipped${Colours.Reset} = ${modsSkipped})`,
     );
+
+    return {
+        timestamp: updateStartTime.toISOString(),
+        numInserted: inserted,
+        numUpdated: updated,
+        numErrored: modsErrored,
+        numSkipped: modsSkipped,
+    };
 }
 
 export async function performUpdate(): Promise<void> {
@@ -111,9 +185,28 @@ export async function performUpdate(): Promise<void> {
 
     if (lastUpdate === null) return await performInitialWorkshopFetch();
 
-    let timestamp = Math.floor(new Date(lastUpdate.timestamp).getTime() / 1000);
+    let timestamp = Math.floor(new Date(lastUpdate.timestamp).getTime() / 1_000);
 
-    timestamp -= 24 * 60 * 60 * 3; // 3 days because Steam timestamps are weird
+    timestamp -= 24 * 60 * 60 * 1; // 1 day because Steam timestamps are weird sometimes
 
-    await Promise.all([performWorkshopUpdate(timestamp, 'posted'), performWorkshopUpdate(timestamp, 'updated')]);
+    const startTime = Date.now();
+    console.log('Starting background mod fetches');
+
+    const updateResponses = await Promise.all([
+        performBackgroundWorkshopFetch(timestamp, 'posted'),
+        performBackgroundWorkshopFetch(timestamp, 'updated'),
+    ]);
+
+    await setLastUpdate({
+        timestamp:
+            updateResponses[0].timestamp <= updateResponses[1].timestamp
+                ? updateResponses[0].timestamp
+                : updateResponses[1].timestamp,
+        numInserted: updateResponses[0].numInserted + updateResponses[1].numInserted,
+        numUpdated: updateResponses[0].numUpdated + updateResponses[1].numUpdated,
+        numErrored: updateResponses[0].numErrored + updateResponses[1].numErrored,
+        numSkipped: updateResponses[0].numSkipped + updateResponses[1].numSkipped,
+    });
+
+    console.log(`Finished background mod fetches (took ${Math.floor((Date.now() - startTime) / 1_000)}s)`);
 }

--- a/server/src/types/FetchError.ts
+++ b/server/src/types/FetchError.ts
@@ -1,5 +1,0 @@
-export interface FetchError {
-    key: string;
-    message: string;
-    error: unknown;
-}

--- a/server/src/types/PageResponse.ts
+++ b/server/src/types/PageResponse.ts
@@ -1,6 +1,0 @@
-import { ModId } from './Utility';
-
-export interface PageResponse {
-    ids: ModId[];
-    pageCount: number;
-}

--- a/server/tests/classes/WorkshopFetcher.test.ts
+++ b/server/tests/classes/WorkshopFetcher.test.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { WorkshopFetcher } from '../../src/classes/WorkshopFetcher';
 import { WorkshopParser } from '../../src/classes/WorkshopParser';
-import { PageResponse } from '../../src/types/PageResponse';
 
 jest.mock('axios');
 jest.mock('../../src/classes/WorkshopParser');
@@ -12,7 +11,6 @@ const mockedWorkshopParser = jest.mocked(WorkshopParser);
 describe(WorkshopFetcher.name, () => {
     describe(WorkshopFetcher.prototype.fetchNumPages.name, () => {
         const data = 'fake data';
-        const response: PageResponse = { ids: [], pageCount: 123 };
 
         afterAll(() => {
             jest.clearAllMocks();
@@ -20,7 +18,7 @@ describe(WorkshopFetcher.name, () => {
 
         beforeAll(async () => {
             mockedAxios.get.mockResolvedValueOnce({ data });
-            mockedWorkshopParser.parsePage.mockReturnValueOnce(response as unknown as string[]);
+            mockedWorkshopParser.parsePageCount.mockReturnValueOnce(123);
 
             await new WorkshopFetcher(false).fetchNumPages();
         });
@@ -34,12 +32,12 @@ describe(WorkshopFetcher.name, () => {
         });
 
         it('parses the response', () => {
-            expect(mockedWorkshopParser.parsePage).toBeCalledTimes(1);
-            expect(mockedWorkshopParser.parsePage).toBeCalledWith(data, true);
+            expect(mockedWorkshopParser.parsePageCount).toBeCalledTimes(1);
+            expect(mockedWorkshopParser.parsePageCount).toBeCalledWith(data);
         });
     });
 
-    describe(WorkshopFetcher.fetchSingleItem.name, () => {
+    describe(WorkshopFetcher.fetchMod.name, () => {
         const id = 'fake id';
         const data = 'fake data';
 
@@ -50,7 +48,7 @@ describe(WorkshopFetcher.name, () => {
         beforeAll(async () => {
             mockedAxios.get.mockResolvedValueOnce({ data });
 
-            await WorkshopFetcher.fetchSingleItem(id);
+            await WorkshopFetcher.fetchMod(id);
         });
 
         it('makes a network request', () => {
@@ -63,6 +61,8 @@ describe(WorkshopFetcher.name, () => {
 
         it('parses the response', () => {
             expect(mockedWorkshopParser).toBeCalledTimes(1);
+
+            // all non-static WorkshopParser methods should be called
             for (const method of Object.keys(mockedWorkshopParser.prototype)) {
                 expect(mockedWorkshopParser.prototype[method as keyof WorkshopParser]).toBeCalledTimes(1);
             }


### PR DESCRIPTION
Resolves #2 

- `WorkshopFetcher` now has its mass network requests handled via a `MassRequester` class instance, which does chunking internally.
- Switched to event-emitter architecture for mass network requests (e.g. fetching all mods).
- Mod fetching now happens per page chunk instead of all at once.
- Database upserting now happens per mod chunk instead of all at once.
- `ModService`'s upsert function now returns the number of inserted and updated mods.
- Hidden mods on the Steam workshop are now skipped instead of throwing an error.
- There is now a (configurable) delay between chunk fetches.
- Fixed some mods having `null` as their `updated` value instead of `undefined`, causing the search endpoint to fail.
- Fixed background updates not having a correct timestamp.
- Fixed updates sometimes hanging when 0 items were found.
- `ProgressLogger` now has a title.
- `ProgressLogger` no longer relogs its output if it's output hasn't changed since the last log.

Please check comments carefully, as they have been copied over from the old `WorkshopFetcher` class so may contain dead links, outdated params, etc...

In terms of memory usage:
- Before these changes were implemented, an initial workshop fetch of all mods would result in a gradual climb towards ~1.4GB memory usage.
- After these changes were implemented, the same fetch now results in a repeating cycle of memory usage going from ~400MB to ~700MB, which theoretically can be reduced even further by decreasing the chunk size.

This PR will require a complete re-fetching of the mods database.