### PR TITLE
Tag Chaining Options

### DIFF
--- a/client/src/global/searchOptions.ts
+++ b/client/src/global/searchOptions.ts
@@ -1,5 +1,5 @@
 import { ModDLCs } from '../types/shared/ModDLCs';
-import { ModSearchOptions } from '../types/shared/ModSearchOptions';
+import { SearchChainOptions, ModSearchOptions } from '../types/shared/ModSearchOptions';
 import { ModSortOptions } from '../types/shared/ModSortOptions';
 import { ModTags } from '../types/shared/ModTags';
 
@@ -12,8 +12,10 @@ const defaultSearchOptions: ModSearchOptions = {
     sortDirection: 1,
     tagsInclude: ModTags.None,
     tagsExclude: ModTags.None,
+    tagsIncludeChain: SearchChainOptions.Or,
     dlcsInclude: ModDLCs.None,
     dlcsExclude: ModDLCs.None,
+    dlcsIncludeChain: SearchChainOptions.Or,
 };
 
 export function loadSearchOptions(): ModSearchOptions {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -509,7 +509,7 @@
                 "schema": {
                     "$ref": "#/components/schemas/SearchChainOptions"
                 },
-                "example": 1
+                "example": 0
             },
             "dlcsInclude": {
                 "in": "query",
@@ -536,7 +536,7 @@
                 "schema": {
                     "$ref": "#/components/schemas/SearchChainOptions"
                 },
-                "example": 1
+                "example": 0
             },
             "search": {
                 "in": "query",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -59,10 +59,16 @@
                         "$ref": "#/components/parameters/tagsExclude"
                     },
                     {
+                        "$ref": "#/components/parameters/tagsIncludeChain"
+                    },
+                    {
                         "$ref": "#/components/parameters/dlcsInclude"
                     },
                     {
                         "$ref": "#/components/parameters/dlcsExclude"
+                    },
+                    {
+                        "$ref": "#/components/parameters/dlcsIncludeChain"
                     },
                     {
                         "$ref": "#/components/parameters/search"
@@ -415,6 +421,11 @@
                     "dependencyIds",
                     "dependencyNames"
                 ]
+            },
+            "SearchChainOptions": {
+                "type": "integer",
+                "enum": [0, 1],
+                "description": "0 for and, 1 for or."
             }
         },
         "parameters": {
@@ -491,6 +502,15 @@
                 },
                 "example": 0
             },
+            "tagsIncludeChain": {
+                "in": "query",
+                "name": "tagsIncludeChain",
+                "required": true,
+                "schema": {
+                    "$ref": "#/components/schemas/SearchChainOptions"
+                },
+                "example": 1
+            },
             "dlcsInclude": {
                 "in": "query",
                 "name": "dlcsInclude",
@@ -508,6 +528,15 @@
                     "$ref": "#/components/schemas/ModDLCs"
                 },
                 "example": 0
+            },
+            "dlcsIncludeChain": {
+                "in": "query",
+                "name": "dlcsIncludeChain",
+                "required": true,
+                "schema": {
+                    "$ref": "#/components/schemas/SearchChainOptions"
+                },
+                "example": 1
             },
             "search": {
                 "in": "query",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -425,7 +425,7 @@
             "SearchChainOptions": {
                 "type": "integer",
                 "enum": [0, 1],
-                "description": "0 for and, 1 for or."
+                "description": "0 for \"and\", 1 for \"or\"."
             }
         },
         "parameters": {

--- a/server/src/types/shared/ModSearchOptions.ts
+++ b/server/src/types/shared/ModSearchOptions.ts
@@ -4,6 +4,11 @@ import { ModTags } from './ModTags';
 import { PaginationParams } from './Page';
 import { ModId } from './Utility';
 
+export enum SearchChainOptions {
+    And = 0,
+    Or = 1,
+}
+
 /**
  * Include operations are OR chained.
  *
@@ -22,8 +27,10 @@ export interface ModSearchOptions extends PaginationParams {
     sortDirection: 1 | -1;
     tagsInclude: ModTags;
     tagsExclude: ModTags;
+    tagsIncludeChain: SearchChainOptions;
     dlcsInclude: ModDLCs;
     dlcsExclude: ModDLCs;
+    dlcsIncludeChain: SearchChainOptions;
     /**
      * If provided, sort direction will be based on title relevance instead of the provided sort direction.
      *

--- a/server/src/types/shared/ModSearchOptions.ts
+++ b/server/src/types/shared/ModSearchOptions.ts
@@ -10,7 +10,7 @@ export enum SearchChainOptions {
 }
 
 /**
- * Include operations are OR chained.
+ * Include operations are OR chained by default.
  *
  * Exclude operations are AND chained, and take priority over include operations.
  *


### PR DESCRIPTION
Resolves #14.

Adds "chaining options" for the `dlcsInclude` and `tagsInclude` search options, these options define whether tags/dlcs should be 'AND' or 'OR' chained.

- 'AND' chained bitfields require all the bits to be set, e.g. a mod must have at least **every tag** specified.
- 'OR' chained bitfields require any of the bits to be set, e.g. a mod must have at least **one of the tags** specified.
  - This was the previous default for both DLCs and tags.

The `dlcsExclude` and `tagsExclude` options do not have configurable chaining, and they remain 'AND' chained (see #14 for more info on why this is).